### PR TITLE
Created a specific FederalJob object (contains GS Level and salary) for the FederalResume object

### DIFF
--- a/src/resumeBuilder/FederalJob.java
+++ b/src/resumeBuilder/FederalJob.java
@@ -1,0 +1,82 @@
+package resumeBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class FederalJob {
+	String startDate;
+	String endDate;
+	String jobTitle;
+	String GSLevel;
+	String salary;
+	String company;
+	List<String> descriptions;
+	
+	public FederalJob(String jobTitle, String startDate, String endDate, String company, String GSLevel, String salary) {
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.jobTitle = jobTitle;
+		this.company = company;
+		this.GSLevel = GSLevel;
+		this.salary = salary;
+		this.descriptions = new ArrayList<String>();
+	}
+	
+	public FederalJob() {}
+	
+	public void addBullet(String s) {
+		this.descriptions.add(s);
+	}
+
+	public String getStartDate() {
+		return this.startDate;
+	}
+
+	public void setStartDate(String startDate) {
+		this.startDate = startDate;
+	}
+
+	public String getEndDate() {
+		return this.endDate;
+	}
+
+	public void setEndDate(String endDate) {
+		this.endDate = endDate;
+	}
+
+	public String getJobTitle() {
+		return this.jobTitle;
+	}
+
+	public void setJobTitle(String jobTitle) {
+		this.jobTitle = jobTitle;
+	}
+
+	public String getCompany() {
+		return this.company;
+	}
+
+	public void setCompany(String company) {
+		this.company = company;
+	}
+	
+	public String getGSLevel() {
+		return this.GSLevel;
+	}
+	
+	public void setGSLevel(String GSLevel) {
+		this.GSLevel = GSLevel;
+	}
+	
+	public String getSalary() {
+		return this.salary;
+	}
+	
+	public void setSalary(String salary) {
+		this.salary = salary;
+	}
+
+	public List<String> getDescriptions() {
+		return this.descriptions;
+	}
+}

--- a/src/resumeBuilder/FederalResume.java
+++ b/src/resumeBuilder/FederalResume.java
@@ -10,15 +10,9 @@ public class FederalResume implements Resume{
 	private String federalExperience;
 	private String clearance;
 	private String purposeStatement;
-	//private FederalResumeHeaderInfo federalResumeHeaderInfo;
 	private List<School> schools = new ArrayList<School>();
 	private List<Activity> activities = new ArrayList<Activity>();
-	private List<Job> jobs = new ArrayList<Job>();
-		//Include: start end dates
-		//Num hrs per week
-		//GS level and position title
-		//Salary
-		//Description
+	private List<FederalJob> federalJobs = new ArrayList<FederalJob>();
 	private List<String> skills = new ArrayList<String>();
 	private List<References> references = new ArrayList<References>();
 	
@@ -65,13 +59,6 @@ public class FederalResume implements Resume{
 	public String getPurposeStatement() {
 		return this.purposeStatement;
 	}
-//	public void setFederalResumeHeaderInfo(FederalResumeHeaderInfo federalResumeHeaderInfo) {
-//		this.federalResumeHeaderInfo = federalResumeHeaderInfo;
-//	}
-//	
-//	public FederalResumeHeaderInfo getFederalResumeHeaderInfo() {
-//		return this.federalResumeHeaderInfo;
-//	}
 
 	@Override
 	public void addSchool(School school) {
@@ -91,14 +78,12 @@ public class FederalResume implements Resume{
 		return this.activities;
 	}
 
-	@Override
-	public void addJob(Job job) {
-		jobs.add(job);		
+	public void addFederalJob(FederalJob federalJob) {
+		federalJobs.add(federalJob);		
 	}
 
-	@Override
-	public List<Job> getJobs() {
-		return jobs;
+	public List<FederalJob> getFederalJobs() {
+		return federalJobs;
 	}
 	
 	public void addSkill(String skill) {
@@ -115,5 +100,16 @@ public class FederalResume implements Resume{
 
 	public List<References> getReferences() {
 		return this.references;
+	}
+
+	@Override
+	public void addJob(Job job) {
+		// TODO Auto-generated method stub
+	}
+
+	@Override
+	public List<Job> getJobs() {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/resumeBuilder/FederalResumeMenu.java
+++ b/src/resumeBuilder/FederalResumeMenu.java
@@ -132,8 +132,8 @@ public class FederalResumeMenu implements Menu {
 		return currentFederalResume;
 	}
 
-	@Override
-	public Resume processWorkExperience(Resume currentFederalResume) {
+//	@Override
+	public Resume processWorkExperience(FederalResume currentFederalResume) {
 		
 		System.out.println("Please enter your the name of the company you would like to add.");
 		String companyName = keyboardIn.nextLine(); 
@@ -147,11 +147,17 @@ public class FederalResumeMenu implements Menu {
 		System.out.println("What was your title at "+companyName+"?");
 		String jobTitle = keyboardIn.nextLine(); 
 		
-		Job currentJob = new Job(jobTitle, startDate, endDate, companyName);
+		System.out.println("What was your GS Level at "+companyName+"? (Press enter if not applicable)");
+		String GSLevel = keyboardIn.nextLine(); 
 		
-		currentJob=promptForResponsibilities(currentJob);
+		System.out.println("What was your salary at "+companyName+"?");
+		String salary = keyboardIn.nextLine(); 
 		
-		currentFederalResume.addJob(currentJob);
+		FederalJob currentFederalJob = new FederalJob(jobTitle, startDate, endDate, companyName, GSLevel, salary);
+		
+		currentFederalJob=promptForFedResponsibilities(currentFederalJob);
+		
+		currentFederalResume.addFederalJob(currentFederalJob);
 		
 		return currentFederalResume;
 	}
@@ -247,9 +253,7 @@ public class FederalResumeMenu implements Menu {
 		reference.addReferenceEmail(referenceEmail);
 		reference.addReferencePhoneNumber(referencePhoneNumber);
 		reference.addReferenceOrganization(referenceOrg);
-		
-		//TODO: ability for user to add multiple references
-		
+				
 		return currentFederalResume;
 	}
 
@@ -268,20 +272,24 @@ public class FederalResumeMenu implements Menu {
 
 	@Override
 	public Job promptForResponsibilities(Job currentJob) {
+		return null;
+	}
+	
+	public FederalJob promptForFedResponsibilities(FederalJob currentFederalJob) {
 		String userInput="";
 		
 		while(!userInput.equals("done")) {
-			System.out.println("Please enter the next responsibility you have/had at "+currentJob.getCompany()+". Or, type 'done' if you are finished.");
+			System.out.println("Please enter the next responsibility you have/had at "+currentFederalJob.getCompany()+". Or, type 'done' if you are finished.");
 			userInput=keyboardIn.nextLine();
 			
 			if(!userInput.equals("done")) {
-				currentJob.addBullet(userInput);
+				currentFederalJob.addBullet(userInput);
 			}
 		}
 		
 		System.out.println("Exiting job responsibilities section...");
 		
-		return currentJob;
+		return currentFederalJob;
 	}
 
 	@Override
@@ -306,5 +314,11 @@ public class FederalResumeMenu implements Menu {
 	public void displayExitMessage() {
 		System.out.println("Exiting Resume Builder...");
 		System.out.println("Goodbye!");
+	}
+
+	@Override
+	public Resume processWorkExperience(Resume currentResume) {
+		// TODO Auto-generated method stub
+		return null;
 	}
 }

--- a/src/resumeBuilder/Menu.java
+++ b/src/resumeBuilder/Menu.java
@@ -4,6 +4,8 @@ public interface Menu {
 	
 	public void runMenu();
 	
+	public void displayExitMessage();
+	
 	public void displayMenu();
 	
 	public int getMenuSelection();
@@ -15,6 +17,10 @@ public interface Menu {
 	public Resume processAcademicInformation(Resume currentResume);
 	
 	public Resume processWorkExperience(Resume currentResume);
+	
+	public Job promptForResponsibilities(Job currentJob);
+	
+	public School promptForHonorsOrAwards(School currentSchool);
 	
 	public void resetMenu(Resume currentResume);
 	

--- a/src/resumeBuilder/School.java
+++ b/src/resumeBuilder/School.java
@@ -49,7 +49,7 @@ public class School {
 	}
 
 	public List<String> getHonorsAwards() {
-		return this.honors_awards;
+		return this.honorsAwards;
 	}
 	
 }


### PR DESCRIPTION
On federal resumes, jobs also need to list the GS Level (if a government job) and the salary. There were two ways I thought about incorporating this:

1. **(This is the one I ended up implementing)** Creating a separate FederalJob class and adding it to the FederalResume object. I left the Job methods blank and unused, since they are required by the Resume interface, and I did the same for the FederalResumeMenu methods using 'Job' objects required by the Menu interface.

2. Make a Job interface and create StandardJob and FederalJob classes that implement it. I think this would require more changes than the first option. 

Since FederalResume is the only template that requires a special version of the Job object, I figured the first option would cause as little change as possible, but let me know what you guys think.