### PR TITLE
Edit resume content

### DIFF
--- a/src/resumeBuilder/Activity.java
+++ b/src/resumeBuilder/Activity.java
@@ -57,4 +57,9 @@ public class Activity {
 	public List<String> getDescriptions() {
 		return descriptions;
 	}
+	
+	public String toString() {
+		return "Organization: "+this.organization+", Role: "+this.role+", Time: "+this.startDate+"-"+this.endDate+", Descriptions: "+this.descriptions.toString();
+
+	}
 }

--- a/src/resumeBuilder/Certification.java
+++ b/src/resumeBuilder/Certification.java
@@ -48,4 +48,9 @@ public class Certification {
 	public void setDetails(String details) {
 		this.details = details;
 	}
+	
+	public String toString() {
+		return "Title: "+this.title+", Host Organization: "+this.hostName+", Earned: "+this.dateEarned+", Details: "+this.details;
+
+	}
 }

--- a/src/resumeBuilder/ContactInformation.java
+++ b/src/resumeBuilder/ContactInformation.java
@@ -30,4 +30,8 @@ public class ContactInformation {
 	public String getAddress() {
 		return this.address;
 	}
+	
+	public String toString() {
+		return "Name: "+this.name+", Email: "+this.email+", Phone #: "+this.phone_number+", Address: "+this.address;
+	}
 }

--- a/src/resumeBuilder/FederalJob.java
+++ b/src/resumeBuilder/FederalJob.java
@@ -79,4 +79,9 @@ public class FederalJob {
 	public List<String> getDescriptions() {
 		return this.descriptions;
 	}
+	
+	public String toString() {
+		return "Company: "+this.company+", Title: "+this.jobTitle+", Time: "+this.startDate+"-"+this.endDate+", GS Level: "+this.GSLevel+", Salary: "+this.salary+", Descriptions: "+this.descriptions.toString();
+
+	}
 }

--- a/src/resumeBuilder/FederalResume.java
+++ b/src/resumeBuilder/FederalResume.java
@@ -5,11 +5,11 @@ import java.util.List;
 
 public class FederalResume implements Resume{
 	
-	private ContactInformation contactInfo;
-	private String citizenshipStatus;
-	private String federalExperience;
-	private String clearance;
-	private String purposeStatement;
+	private ContactInformation contactInfo = new ContactInformation();
+	private String citizenshipStatus = "";
+	private String federalExperience = "";
+	private String clearance = "";
+	private String purposeStatement = "";
 	private List<School> schools = new ArrayList<School>();
 	private List<Activity> activities = new ArrayList<Activity>();
 	private List<FederalJob> federalJobs = new ArrayList<FederalJob>();
@@ -75,7 +75,7 @@ public class FederalResume implements Resume{
 		this.activities.add(activity);
 	}
 	
-	public List<Activity> getActivity() {
+	public List<Activity> getActivities() {
 		return this.activities;
 	}
 
@@ -113,4 +113,130 @@ public class FederalResume implements Resume{
 		return this.references;
 	}
 
+	public void printContactInfo() {
+		System.out.println("Contact Information");
+		System.out.println("-------------");
+		
+		this.contactInfo.toString();
+	}
+	
+	public void printCitizenshipStatus() {
+		System.out.println("Citizenship Status");
+		System.out.println("-------------");
+		System.out.print(this.citizenshipStatus);
+	}
+	
+	public void printFederalExperience() {
+		System.out.println("Government or Military Experience");
+		System.out.println("-------------");
+		System.out.print(this.federalExperience);
+	}
+	
+	public void printClearance() {
+		System.out.println("Clearance");
+		System.out.println("-------------");
+		System.out.print(this.clearance);
+	}
+	
+	public void printPurposeStatement() {
+		System.out.println("Purpose Statement");
+		System.out.println("-------------");
+		System.out.print(this.purposeStatement);
+	}
+	
+	public void printSchools() {
+		System.out.println("Academic History");
+		System.out.println("-------------");
+		
+		for(School currentSchool : this.getSchools()) {
+			System.out.println("* "+currentSchool.toString());
+		}
+	}
+	
+	public void printActivities() {
+		System.out.println("Volunteer Work and Community Involvement");
+		System.out.println("-------------");
+		
+		for(Activity currentActivity : this.getActivities()) {
+			System.out.println("* "+currentActivity.toString());
+		}
+	}
+	
+	public void printJobs() {
+		System.out.println("Regular Work Experience");
+		System.out.println("-------------");
+		
+		for(Job currentJob : this.getJobs()) {
+			System.out.println("* "+currentJob.toString());
+		}
+	}
+	
+	public void printFederalJobs() {
+		System.out.println("Federal Work Experience");
+		System.out.println("-------------");
+		
+		for(FederalJob currentFederalJob : this.getFederalJobs()) {
+			System.out.println("* "+currentFederalJob.toString());
+		}
+	}
+	
+	public void printSkills() {
+		System.out.println("Skills");
+		System.out.println("-------------");
+		
+		for(String currentSkill : this.getSkills()) {
+			System.out.println("* "+currentSkill);
+		}
+	}
+	
+	public void printReferences() {
+		System.out.println("References");
+		System.out.println("-------------");
+		
+		for(References currentReference : this.getReferences()) {
+			System.out.println("* "+currentReference.toString());
+		}
+	}
+	
+	public void printFederalResume() {
+		System.out.println();
+		System.out.println("YOUR CURRENT FEDERAL RESUME CONTENT: ");
+		
+		System.out.println();
+		this.printContactInfo();
+		
+		System.out.println();
+		this.printCitizenshipStatus();
+		
+		System.out.println();
+		this.printFederalExperience();
+		
+		System.out.println();
+		this.printClearance();
+		
+		System.out.println();
+		this.printPurposeStatement();
+		
+		System.out.println();
+		this.printSchools();
+		
+		System.out.println();
+		this.printActivities();
+		
+		System.out.println();
+		this.printJobs();
+		
+		System.out.println();
+		this.printFederalJobs();
+		
+		System.out.println();
+		this.printSkills();
+		
+		System.out.println();
+		this.printReferences();
+		
+		System.out.println();
+		System.out.println("END OF CONTENT");
+		System.out.println();
+	}
 }

--- a/src/resumeBuilder/FederalResume.java
+++ b/src/resumeBuilder/FederalResume.java
@@ -117,7 +117,7 @@ public class FederalResume implements Resume{
 		System.out.println("Contact Information");
 		System.out.println("-------------");
 		
-		this.contactInfo.toString();
+		System.out.println(this.contactInfo.toString());
 	}
 	
 	public void printCitizenshipStatus() {

--- a/src/resumeBuilder/FederalResume.java
+++ b/src/resumeBuilder/FederalResume.java
@@ -68,7 +68,22 @@ public class FederalResume implements Resume{
 
 	@Override
 	public List<School> getSchools() {
-		return schools;
+		return this.schools;
+	}
+	
+	public boolean removeSchool(String schoolName) {
+		for(School currentSchool : this.getSchools()) {
+			String currentSchoolName = currentSchool.getSchoolName();
+			if(currentSchoolName.equals(schoolName)) {
+				this.schools.remove(currentSchool);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseSchools() {
+		this.schools = new ArrayList<School>();
 	}
 	
 	public void addActivity(Activity activity) {
@@ -78,23 +93,68 @@ public class FederalResume implements Resume{
 	public List<Activity> getActivities() {
 		return this.activities;
 	}
+	
+	public boolean removeActivity(String organization) {
+		for(Activity currentActivity : this.getActivities()) {
+			String currentOrganization = currentActivity.getOrganization();
+			if(currentOrganization.equals(organization)) {
+				this.activities.remove(currentActivity);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseActivities() {
+		this.activities = new ArrayList<Activity>();
+	}
 
 	public void addFederalJob(FederalJob federalJob) {
-		federalJobs.add(federalJob);		
+		this.federalJobs.add(federalJob);		
 	}
 
 	public List<FederalJob> getFederalJobs() {
-		return federalJobs;
+		return this.federalJobs;
+	}
+	
+	public boolean removeFederalJob(String companyName) {
+		for(FederalJob currentJob : this.getFederalJobs()) {
+			String currentCompanyName = currentJob.getCompany();
+			if(currentCompanyName.equals(companyName)) {
+				this.federalJobs.remove(currentJob);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseFederalJobs() {
+		this.federalJobs = new ArrayList<FederalJob>();
 	}
 	
 	@Override
 	public void addJob(Job job) {
-		jobs.add(job);
+		this.jobs.add(job);
 	}
 
 	@Override
 	public List<Job> getJobs() {
-		return jobs;
+		return this.jobs;
+	}
+	
+	public boolean removeJob(String companyName) {
+		for(Job currentJob : this.getJobs()) {
+			String currentCompanyName = currentJob.getCompany();
+			if(currentCompanyName.equals(companyName)) {
+				this.jobs.remove(currentJob);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseJobs() {
+		this.jobs = new ArrayList<Job>();
 	}
 	
 	public void addSkill(String skill) {
@@ -105,12 +165,35 @@ public class FederalResume implements Resume{
 		return this.skills;
 	}
 	
+	public boolean removeSkill(String skill) {
+		return this.skills.remove(skill);
+	}
+	
+	public void eraseSkills() {
+		this.skills = new ArrayList<String>();
+	}
+	
 	public void addReference(References reference) {
 		this.references.add(reference);
 	}
 
 	public List<References> getReferences() {
 		return this.references;
+	}
+	
+	public boolean removeReference(String name) {
+		for(References currentReference : this.getReferences()) {
+			String currentName = currentReference.getReferenceName();
+			if(currentName.equals(name)) {
+				this.references.remove(currentReference);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseReferences() {
+		this.references = new ArrayList<References>();
 	}
 
 	public void printContactInfo() {

--- a/src/resumeBuilder/FederalResumeMenu.java
+++ b/src/resumeBuilder/FederalResumeMenu.java
@@ -47,13 +47,13 @@ public class FederalResumeMenu implements Menu {
 			currentFederalResume=processContactInformation(currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==2) {
-			currentFederalResume=processAcademicInformation(currentFederalResume);
+			currentFederalResume=addOrRemoveSchool(currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==3) {
-			currentFederalResume=processFederalWorkExperience((FederalResume) currentFederalResume);
+			currentFederalResume=addOrRemoveFederalJob(currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==4) {
-			currentFederalResume=processWorkExperience(currentFederalResume);
+			currentFederalResume=addOrRemoveJob(currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==5) {				
 			currentFederalResume=processCitizenshipStatus((FederalResume) currentFederalResume);
@@ -68,13 +68,13 @@ public class FederalResumeMenu implements Menu {
 			currentFederalResume=processPurposeStatement((FederalResume) currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==9) {				
-			currentFederalResume=processVolunteerExperience((FederalResume) currentFederalResume);
+			currentFederalResume=addOrRemoveVolunteerExperience(currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==10) {				
-			currentFederalResume=processSkill((FederalResume) currentFederalResume);
+			currentFederalResume=addOrRemoveSkill((FederalResume) currentFederalResume);
 			resetMenu(currentFederalResume);
 		} else if (federalResumeOption==11) {				
-				currentFederalResume=processReference((FederalResume) currentFederalResume);
+				currentFederalResume=addOrRemoveReference(currentFederalResume);
 				resetMenu(currentFederalResume);
 		} else if (federalResumeOption==12){
 			((FederalResume) currentFederalResume).printFederalResume();
@@ -391,6 +391,196 @@ public class FederalResumeMenu implements Menu {
 		System.out.println("Exiting academic honors/awards section...");
 		
 		return currentSchool;
+	}
+	
+	public void displayAddOrRemove() {
+		System.out.println("Please select what you would like to do.");
+		System.out.println("1. Add an entry.");
+		System.out.println("2. Remove an entry.");
+		System.out.println("3. Erase all entries.");
+		System.out.println("4. Return");
+	}
+	
+	public int promptForAddOrRemove() {
+		displayAddOrRemove();
+		
+		int selection = getMenuSelection();
+		
+		while(selection>4 || selection<1) {
+			System.out.println("That is not a valid selection. Please try again.");
+			displayAddOrRemove();
+			selection = getMenuSelection();
+		}
+		
+		return selection;
+	}
+	
+	public Resume addOrRemoveSchool(Resume currentFederalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentFederalResume=processAcademicInformation(currentFederalResume);	
+		} else if(selection == 2) {
+			currentFederalResume=processSchoolRemoval(currentFederalResume);
+		} else if(selection == 3) {
+			((FederalResume) currentFederalResume).eraseSchools();
+			System.out.println("All academic history has been erased.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume processSchoolRemoval(Resume currentFederalResume) {
+		System.out.println("Please enter the name of the school you would like to delete (exactly as entered previously.");
+		String schoolName = keyboardIn.nextLine();
+		if(((FederalResume) currentFederalResume).removeSchool(schoolName)) {
+			System.out.println(schoolName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find school with that name.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume addOrRemoveFederalJob(Resume currentFederalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentFederalResume=processFederalWorkExperience((FederalResume) currentFederalResume);
+		} else if(selection == 2) {
+			currentFederalResume=processFederalJobRemoval(currentFederalResume);
+		} else if(selection == 3) {
+			((FederalResume) currentFederalResume).eraseFederalJobs();
+			System.out.println("All federal work experience has been erased.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume processFederalJobRemoval(Resume currentFederalResume) {
+		System.out.println("Please enter the company name of the federal job you would like to delete (exactly as entered previously.");
+		String companyName = keyboardIn.nextLine();
+		if(((FederalResume) currentFederalResume).removeFederalJob(companyName)) {
+			System.out.println(companyName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find federal job with that company name.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume addOrRemoveJob(Resume currentFederalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentFederalResume=processWorkExperience(currentFederalResume);
+		} else if(selection == 2) {
+			currentFederalResume=processJobRemoval(currentFederalResume);
+		} else if(selection == 3) {
+			((FederalResume) currentFederalResume).eraseJobs();
+			System.out.println("All regular work experience has been erased.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume processJobRemoval(Resume currentFederalResume) {
+		System.out.println("Please enter the company name of the job you would like to delete (exactly as entered previously.");
+		String companyName = keyboardIn.nextLine();
+		if(((FederalResume) currentFederalResume).removeJob(companyName)) {
+			System.out.println(companyName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find job with that company name.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume addOrRemoveVolunteerExperience(Resume currentFederalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentFederalResume=processVolunteerExperience((FederalResume) currentFederalResume);
+		} else if(selection == 2) {
+			currentFederalResume=processVolunteerExperienceRemoval(currentFederalResume);
+		} else if(selection == 3) {
+			((FederalResume) currentFederalResume).eraseActivities();
+			System.out.println("All activities have been erased.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume processVolunteerExperienceRemoval(Resume currentFederalResume) {
+		System.out.println("Please enter the organization name of the volunteer experience you would like to delete (exactly as entered previously.");
+		String organizationName = keyboardIn.nextLine();
+		if(((FederalResume) currentFederalResume).removeActivity(organizationName)) {
+			System.out.println(organizationName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find volunteer experience with that organization name.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume addOrRemoveSkill(Resume currentFederalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentFederalResume=processSkill((FederalResume) currentFederalResume);
+		} else if(selection == 2) {
+			currentFederalResume=processSkillRemoval(currentFederalResume);
+		} else if(selection == 3) {
+			((FederalResume) currentFederalResume).eraseSkills();
+			System.out.println("All skills been erased.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume processSkillRemoval(Resume currentFederalResume) {
+		System.out.println("Please enter the skill you would like to delete (exactly as entered previously.");
+		String skill = keyboardIn.nextLine();
+		if(((FederalResume) currentFederalResume).removeSkill(skill)) {
+			System.out.println(skill+" has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find that skill.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume addOrRemoveReference(Resume currentFederalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentFederalResume=processReference((FederalResume) currentFederalResume);	
+		} else if(selection == 2) {
+			currentFederalResume=processReferenceRemoval(currentFederalResume);
+		} else if(selection == 3) {
+			((FederalResume) currentFederalResume).eraseReferences();
+			System.out.println("All references have been erased.");
+		}
+		
+		return currentFederalResume;
+	}
+	
+	public Resume processReferenceRemoval(Resume currentFederalResume) {
+		System.out.println("Please enter the name of the reference you would like to delete (exactly as entered previously.");
+		String referenceName = keyboardIn.nextLine();
+		if(((FederalResume) currentFederalResume).removeReference(referenceName)) {
+			System.out.println(referenceName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find reference with that name.");
+		}
+		
+		return currentFederalResume;
 	}
 
 	@Override

--- a/src/resumeBuilder/FederalResumeMenu.java
+++ b/src/resumeBuilder/FederalResumeMenu.java
@@ -18,7 +18,7 @@ public class FederalResumeMenu implements Menu {
 
 	@Override
 	public void displayMenu() {
-		System.out.println("Please select the information you would like to add next.");
+		System.out.println("Please select the information you would like to add/edit next.");
 		System.out.println("1. Contact Information");
 		System.out.println("2. Academic History");
 		System.out.println("3. Federal Work Experience");
@@ -93,6 +93,8 @@ public class FederalResumeMenu implements Menu {
 
 	@Override
 	public Resume processContactInformation(Resume currentFederalResume) {
+		System.out.println("If you have already entered contact information, what you are entering now will replace that.");
+		System.out.println();
 		
 		System.out.println("Please enter your full name.");
 		String firstName = keyboardIn.nextLine(); 
@@ -194,6 +196,8 @@ public class FederalResumeMenu implements Menu {
 	}
 	
 	private FederalResume processCitizenshipStatus(FederalResume currentFederalResume) {
+		System.out.println("If you have already entered your citizenship status, what you are entering now will replace that.");
+		System.out.println();
 		
 		System.out.println("Please enter your citizenship status (e.g., US Citizen, Work Visa.");
 		String citizenshipStatus = keyboardIn.nextLine(); 
@@ -204,6 +208,8 @@ public class FederalResumeMenu implements Menu {
 	}
 	
 	private FederalResume processFederalExperience(FederalResume currentFederalResume) {
+		System.out.println("If you have already entered your government experience, what you are entering now will replace that.");
+		System.out.println();
 		
 		System.out.println("Please enter your government experience (e.g., military, federal, or state.");
 		String federalExperience = keyboardIn.nextLine(); 
@@ -214,6 +220,8 @@ public class FederalResumeMenu implements Menu {
 	}
 
 	private FederalResume processClearance(FederalResume currentFederalResume) {
+		System.out.println("If you have already entered your clearance level, what you are entering now will replace that.");
+		System.out.println();
 		
 		System.out.println("Please enter your clearance level (e.g., Top Secret, Secret). If you don't have a clearance, just press 'Enter.'");
 		String clearance = keyboardIn.nextLine(); 
@@ -224,6 +232,8 @@ public class FederalResumeMenu implements Menu {
 	}
 	
 	private FederalResume processPurposeStatement(FederalResume currentFederalResume) {
+		System.out.println("If you have already entered your purpose statement, what you are entering now will replace that.");
+		System.out.println();
 		
 		System.out.println("Please enter a purpose statement about the roles you're looking for.");
 		String purposeStatement = keyboardIn.nextLine(); 

--- a/src/resumeBuilder/FederalResumeMenu.java
+++ b/src/resumeBuilder/FederalResumeMenu.java
@@ -30,8 +30,9 @@ public class FederalResumeMenu implements Menu {
 		System.out.println("9. Volunteer Work and Community Involvement");
 		System.out.println("10. Skills");
 		System.out.println("11. References");
-		System.out.println("12. Save as word document");
-		System.out.println("13. Exit");
+		System.out.println("12. View current content");
+		System.out.println("13. Save as word document");
+		System.out.println("14. Exit");
 		//Options from: https://www.sec.gov/jobs/sample-resume/sample-resume.pdf		
 	}
 
@@ -75,7 +76,10 @@ public class FederalResumeMenu implements Menu {
 		} else if (federalResumeOption==11) {				
 				currentFederalResume=processReference((FederalResume) currentFederalResume);
 				resetMenu(currentFederalResume);
-		} else if (federalResumeOption==12) {
+		} else if (federalResumeOption==12){
+			((FederalResume) currentFederalResume).printFederalResume();
+			resetMenu(currentFederalResume);
+		} else if (federalResumeOption==13) {
 			System.out.println("Word Doc creation unsupported for our federal resume template.");
 			resetMenu(currentFederalResume);
 //			String filePath = promptForDestination();

--- a/src/resumeBuilder/Job.java
+++ b/src/resumeBuilder/Job.java
@@ -57,4 +57,9 @@ public class Job {
 	public List<String> getDescriptions() {
 		return descriptions;
 	}
+	
+	public String toString() {
+		return "Company: "+this.company+", Title: "+this.jobTitle+", Time: "+this.startDate+"-"+this.endDate+", Descriptions: "+this.descriptions.toString();
+
+	}
 }

--- a/src/resumeBuilder/Menu.java
+++ b/src/resumeBuilder/Menu.java
@@ -22,6 +22,15 @@ public interface Menu {
 	
 	public School promptForHonorsOrAwards(School currentSchool);
 	
+	public void displayAddOrRemove();
+	public int promptForAddOrRemove();
+	
+	public Resume addOrRemoveSchool(Resume currentResume);
+	public Resume processSchoolRemoval(Resume currentResume);
+	
+	public Resume addOrRemoveJob(Resume currentResume);
+	public Resume processJobRemoval(Resume currentResume);
+	
 	public void resetMenu(Resume currentResume);
 	
 	public String promptForDestination();

--- a/src/resumeBuilder/Project.java
+++ b/src/resumeBuilder/Project.java
@@ -46,4 +46,9 @@ public class Project {
 	public void setProjectName(String name) {
 		this.name = name;
 	}
+	
+	public String toString() {
+		return "Name: "+this.name+", Time: "+this.startDate+"-"+this.endDate+", Summary: "+this.summary;
+
+	}
 }

--- a/src/resumeBuilder/References.java
+++ b/src/resumeBuilder/References.java
@@ -42,4 +42,8 @@ public class References {
 	public String getReferenceOrganization() {
 		return this.referenceOrganization;
 	}
+	
+	public String toString() {
+		return "Name: "+this.referenceName+", Organization: "+this.referenceOrganization+", Phone #: "+this.referencePhoneNumber+", Email: "+this.referenceEmail;
+	}
 }

--- a/src/resumeBuilder/Resume.java
+++ b/src/resumeBuilder/Resume.java
@@ -8,7 +8,11 @@ public interface Resume {
 	
 	public void addSchool(School school);
 	public List<School> getSchools();
+	public boolean removeSchool(String schoolName);
+	public void eraseSchools();
 	
 	public void addJob(Job job);
 	public List<Job> getJobs();
+	public boolean removeJob(String companyName);
+	public void eraseJobs();
 }

--- a/src/resumeBuilder/School.java
+++ b/src/resumeBuilder/School.java
@@ -50,4 +50,7 @@ public class School {
 		return this.honorsAwards;
 	}
 	
+	public String toString() {
+		return "Name: "+this.schoolName+", Time: "+this.startDate+"-"+this.endDate+", Location: "+this.schoolLocation+", GPA: "+this.gpa+", Honors/Awards: "+this.honorsAwards.toString();
+	}
 }

--- a/src/resumeBuilder/StandardResume.java
+++ b/src/resumeBuilder/StandardResume.java
@@ -9,9 +9,7 @@ public class StandardResume implements Resume {
 	private List<Job> jobs = new ArrayList<Job>();
 	private List<String> skills = new ArrayList<String>();
 	
-	public StandardResume() {
-		
-	}
+	public StandardResume() {}
 	
 	@Override
 	public void setContactInfo(ContactInformation contactInfo) {
@@ -55,7 +53,7 @@ public class StandardResume implements Resume {
 		System.out.println("Contact Information");
 		System.out.println("-------------");
 		
-		this.contactInfo.toString();
+		System.out.println(this.contactInfo.toString());
 	}
 	
 	public void printSchools() {

--- a/src/resumeBuilder/StandardResume.java
+++ b/src/resumeBuilder/StandardResume.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class StandardResume implements Resume {
-	private ContactInformation contactInfo;
+	private ContactInformation contactInfo = new ContactInformation();
 	private List<School> schools = new ArrayList<School>();
 	private List<Job> jobs = new ArrayList<Job>();
 	private List<String> skills = new ArrayList<String>();
@@ -50,5 +50,60 @@ public class StandardResume implements Resume {
 	public List<String> getSkills() {
 		return skills;
 	}
-
+	
+	public void printContactInfo() {
+		System.out.println("Contact Information");
+		System.out.println("-------------");
+		
+		this.contactInfo.toString();
+	}
+	
+	public void printSchools() {
+		System.out.println("Academic History");
+		System.out.println("-------------");
+		
+		for(School currentSchool : this.getSchools()) {
+			System.out.println("* "+currentSchool.toString());
+		}
+	}
+	
+	public void printJobs() {
+		System.out.println("Work Experience");
+		System.out.println("-------------");
+		
+		for(Job currentJob : this.getJobs()) {
+			System.out.println("* "+currentJob.toString());
+		}
+	}
+	
+	public void printSkills() {
+		System.out.println("Skills");
+		System.out.println("-------------");
+		
+		for(String currentSkill : this.getSkills()) {
+			System.out.println("* "+currentSkill);
+		}
+	}
+	
+	public void printStandardResume() {
+		System.out.println();
+		System.out.println("YOUR CURRENT STANDARD RESUME CONTENT: ");
+		
+		System.out.println();
+		this.printContactInfo();
+		
+		System.out.println();
+		this.printSchools();
+		
+		System.out.println();
+		this.printJobs();
+		
+		System.out.println();
+		this.printSkills();
+		
+		System.out.println();
+		System.out.println("END OF CONTENT");
+		
+		System.out.println();
+	}
 }

--- a/src/resumeBuilder/StandardResume.java
+++ b/src/resumeBuilder/StandardResume.java
@@ -30,6 +30,21 @@ public class StandardResume implements Resume {
 	public List<School> getSchools() {
 		return schools;
 	}
+	
+	public boolean removeSchool(String schoolName) {
+		for(School currentSchool : this.getSchools()) {
+			String currentSchoolName = currentSchool.getSchoolName();
+			if(currentSchoolName.equals(schoolName)) {
+				this.schools.remove(currentSchool);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseSchools() {
+		schools = new ArrayList<School>();
+	}
 
 	@Override
 	public void addJob(Job job) {
@@ -41,12 +56,35 @@ public class StandardResume implements Resume {
 		return jobs;
 	}
 	
+	public boolean removeJob(String companyName) {
+		for(Job currentJob : this.getJobs()) {
+			String currentCompanyName = currentJob.getCompany();
+			if(currentCompanyName.equals(companyName)) {
+				this.jobs.remove(currentJob);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseJobs() {
+		jobs = new ArrayList<Job>();
+	}
+	
 	public void addSkill(String skill) {
 		skills.add(skill);
 	}
 	
 	public List<String> getSkills() {
 		return skills;
+	}
+	
+	public boolean removeSkill(String skill) {
+		return this.skills.remove(skill);
+	}
+	
+	public void eraseSkills() {
+		skills = new ArrayList<String>();
 	}
 	
 	public void printContactInfo() {

--- a/src/resumeBuilder/StandardResumeMenu.java
+++ b/src/resumeBuilder/StandardResumeMenu.java
@@ -23,8 +23,9 @@ public class StandardResumeMenu implements Menu{
 		System.out.println("2. Academic History");
 		System.out.println("3. Work Experience");
 		System.out.println("4. Skills");
-		System.out.println("5. Save as word document");
-		System.out.println("6. Exit");
+		System.out.println("5. View current content");
+		System.out.println("6. Save as word document");
+		System.out.println("7. Exit");
 	}
 
 	@Override
@@ -47,6 +48,9 @@ public class StandardResumeMenu implements Menu{
 			currentStandardResume=processSkill((StandardResume) currentStandardResume);
 			resetMenu(currentStandardResume);
 		} else if (standardResumeOption==5) {
+			((StandardResume) currentStandardResume).printStandardResume();
+			resetMenu(currentStandardResume);
+		} else if (standardResumeOption==6) {
 			String filePath = promptForDestination();
 			WordCreator wordCreator = new WordCreator((StandardResume) currentStandardResume, filePath);
 			wordCreator.createWordDocument();

--- a/src/resumeBuilder/StandardResumeMenu.java
+++ b/src/resumeBuilder/StandardResumeMenu.java
@@ -39,13 +39,13 @@ public class StandardResumeMenu implements Menu{
 			currentStandardResume=processContactInformation(currentStandardResume);
 			resetMenu(currentStandardResume);
 		} else if (standardResumeOption==2) {
-			currentStandardResume=processAcademicInformation(currentStandardResume);
+			currentStandardResume=addOrRemoveSchool(currentStandardResume);
 			resetMenu(currentStandardResume);
 		} else if (standardResumeOption==3) {
-			currentStandardResume=processWorkExperience(currentStandardResume);
+			currentStandardResume=addOrRemoveJob(currentStandardResume);
 			resetMenu(currentStandardResume);
 		} else if (standardResumeOption==4) {				
-			currentStandardResume=processSkill((StandardResume) currentStandardResume);
+			currentStandardResume=addOrRemoveSkill(currentStandardResume);
 			resetMenu(currentStandardResume);
 		} else if (standardResumeOption==5) {
 			((StandardResume) currentStandardResume).printStandardResume();
@@ -195,6 +195,112 @@ public class StandardResumeMenu implements Menu{
 		currentJob=promptForResponsibilities(currentJob);
 		
 		currentStandardResume.addJob(currentJob);
+		
+		return currentStandardResume;
+	}
+	
+	public void displayAddOrRemove() {
+		System.out.println("Please select what you would like to do.");
+		System.out.println("1. Add an entry.");
+		System.out.println("2. Remove an entry.");
+		System.out.println("3. Erase all entries.");
+		System.out.println("4. Return");
+	}
+	
+	public int promptForAddOrRemove() {
+		displayAddOrRemove();
+		
+		int selection = getMenuSelection();
+		
+		while(selection>4 || selection<1) {
+			System.out.println("That is not a valid selection. Please try again.");
+			displayAddOrRemove();
+			selection = getMenuSelection();
+		}
+		
+		return selection;
+	}
+	
+	public Resume addOrRemoveSchool(Resume currentStandardResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentStandardResume=processAcademicInformation(currentStandardResume);	
+		} else if(selection == 2) {
+			currentStandardResume=processSchoolRemoval(currentStandardResume);
+		} else if(selection == 3) {
+			((StandardResume) currentStandardResume).eraseSchools();
+			System.out.println("All academic history has been erased.");
+		}
+		
+		return currentStandardResume;
+	}
+	
+	public Resume processSchoolRemoval(Resume currentStandardResume) {
+		System.out.println("Please enter the name of the school you would like to delete (exactly as entered previously.");
+		String schoolName = keyboardIn.nextLine();
+		if(((StandardResume) currentStandardResume).removeSchool(schoolName)) {
+			System.out.println(schoolName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find school with that name.");
+		}
+		
+		return currentStandardResume;
+	}
+	
+	public Resume addOrRemoveJob(Resume currentStandardResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentStandardResume=processWorkExperience(currentStandardResume);	
+		} else if(selection == 2) {
+			currentStandardResume=processJobRemoval(currentStandardResume);
+		} else if(selection == 3) {
+			((StandardResume) currentStandardResume).eraseJobs();
+			System.out.println("All work experience has been erased.");
+		}
+		
+		return currentStandardResume;
+	}
+	
+	public Resume processJobRemoval(Resume currentStandardResume) {
+		System.out.println("Please enter the company name of the job you would like to delete (exactly as entered previously.");
+		String companyName = keyboardIn.nextLine();
+		if(((StandardResume) currentStandardResume).removeJob(companyName)) {
+			System.out.println(companyName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find job with that company name.");
+		}
+		
+		return currentStandardResume;
+	}
+	
+	public Resume addOrRemoveSkill(Resume currentStandardResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentStandardResume=processSkill((StandardResume) currentStandardResume);
+		} else if(selection == 2) {
+			currentStandardResume=processSkillRemoval(currentStandardResume);
+		} else if(selection == 3) {
+			((StandardResume) currentStandardResume).eraseSkills();
+			System.out.println("All skills been erased.");
+		}
+		
+		return currentStandardResume;
+	}
+	
+	public Resume processSkillRemoval(Resume currentStandardResume) {
+		System.out.println("Please enter the skill you would like to delete (exactly as entered previously.");
+		String skill = keyboardIn.nextLine();
+		if(((StandardResume) currentStandardResume).removeSkill(skill)) {
+			System.out.println(skill+" has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find that skill.");
+		}
 		
 		return currentStandardResume;
 	}

--- a/src/resumeBuilder/StandardResumeMenu.java
+++ b/src/resumeBuilder/StandardResumeMenu.java
@@ -18,7 +18,7 @@ public class StandardResumeMenu implements Menu{
 
 	@Override
 	public void displayMenu() {
-		System.out.println("Please select the information you would like to add next.");
+		System.out.println("Please select the information you would like to add/edit next.");
 		System.out.println("1. Contact Information");
 		System.out.println("2. Academic History");
 		System.out.println("3. Work Experience");
@@ -123,6 +123,9 @@ public class StandardResumeMenu implements Menu{
 
 	@Override
 	public Resume processContactInformation(Resume currentStandardResume) {
+		System.out.println("If you have already entered contact information, what you are entering now will replace that.");
+		System.out.println();
+		
 		System.out.println("Please enter your full name.");
 		String firstName = keyboardIn.nextLine(); 
 		

--- a/src/resumeBuilder/TechnicalResume.java
+++ b/src/resumeBuilder/TechnicalResume.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public class TechnicalResume implements Resume {
 	
-	ContactInformation contactInfo;
+	ContactInformation contactInfo = new ContactInformation();
 	private List<School> schools = new ArrayList<School>();
 	private List<Job> jobs = new ArrayList<Job>();
 	private List<Project> projects = new ArrayList<Project>();
@@ -13,6 +13,8 @@ public class TechnicalResume implements Resume {
 	private List<String> programmingLanguageSkills = new ArrayList<String>();
 	private List<Certification> certifications = new ArrayList<Certification>();
 
+	public TechnicalResume() {}
+	
 	@Override
 	public void setContactInfo(ContactInformation contactInfo) {
 		this.contactInfo = contactInfo;
@@ -74,6 +76,97 @@ public class TechnicalResume implements Resume {
 	
 	public List<Certification> getCertifications(){
 		return certifications;
+	}
+	
+	public void printContactInfo() {
+		System.out.println("Contact Information");
+		System.out.println("-------------");
+		
+		this.contactInfo.toString();
+	}
+	
+	public void printSchools() {
+		System.out.println("Academic History");
+		System.out.println("-------------");
+		
+		for(School currentSchool : this.getSchools()) {
+			System.out.println("* "+currentSchool.toString());
+		}
+	}
+	
+	public void printJobs() {
+		System.out.println("Work Experience");
+		System.out.println("-------------");
+		
+		for(Job currentJob : this.getJobs()) {
+			System.out.println("* "+currentJob.toString());
+		}
+	}
+	
+	public void printProjects() {
+		System.out.println("Projects");
+		System.out.println("-------------");
+		
+		for(Project currentProject : this.getProjects()) {
+			System.out.println("* "+currentProject.toString());
+		}
+	}
+	
+	public void printSoftwareSkills() {
+		System.out.println("Software Skills");
+		System.out.println("-------------");
+		
+		for(String currentSkill : this.getSoftwareSkills()) {
+			System.out.println("* "+currentSkill);
+		}
+	}
+	
+	public void printProgrammingLanguageSkills() {
+		System.out.println("Programming Language Skills");
+		System.out.println("-------------");
+		
+		for(String currentSkill : this.getProgrammingLanguageSkills()) {
+			System.out.println("* "+currentSkill);
+		}
+	}
+	
+	public void printCertifications() {
+		System.out.println("Certifications");
+		System.out.println("-------------");
+		
+		for(Certification currentCertification : this.getCertifications()) {
+			System.out.println("* "+currentCertification.toString());
+		}
+	}
+	
+	public void printTechnicalResume() {
+		System.out.println();
+		System.out.println("YOUR CURRENT TECHNICAL RESUME CONTENT: ");
+		
+		System.out.println();
+		this.printContactInfo();
+		
+		System.out.println();
+		this.printSchools();
+		
+		System.out.println();
+		this.printJobs();
+		
+		System.out.println();
+		this.printProjects();
+		
+		System.out.println();
+		this.printSoftwareSkills();
+		
+		System.out.println();
+		this.printProgrammingLanguageSkills();
+		
+		System.out.println();
+		this.printCertifications();
+		
+		System.out.println();
+		System.out.println("END OF CONTENT");
+		System.out.println();
 	}
 	
 }

--- a/src/resumeBuilder/TechnicalResume.java
+++ b/src/resumeBuilder/TechnicalResume.java
@@ -27,55 +27,131 @@ public class TechnicalResume implements Resume {
 
 	@Override
 	public void addSchool(School school) {
-		schools.add(school);
+		this.schools.add(school);
 	}
 
 	@Override
 	public List<School> getSchools() {
-		return schools;
+		return this.schools;
+	}
+	
+	public boolean removeSchool(String schoolName) {
+		for(School currentSchool : this.getSchools()) {
+			String currentSchoolName = currentSchool.getSchoolName();
+			if(currentSchoolName.equals(schoolName)) {
+				this.schools.remove(currentSchool);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseSchools() {
+		this.schools = new ArrayList<School>();
 	}
 
 	@Override
 	public void addJob(Job job) {
-		jobs.add(job);
+		this.jobs.add(job);
 		
 	}
 
 	@Override
 	public List<Job> getJobs() {
-		return jobs;
+		return this.jobs;
+	}
+	
+	public boolean removeJob(String companyName) {
+		for(Job currentJob : this.getJobs()) {
+			String currentCompanyName = currentJob.getCompany();
+			if(currentCompanyName.equals(companyName)) {
+				this.jobs.remove(currentJob);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseJobs() {
+		this.jobs = new ArrayList<Job>();
 	}
 	
 	public void addProject(Project project) {
-		projects.add(project);
+		this.projects.add(project);
 	}
 	
 	public List<Project> getProjects(){
-		return projects;
+		return this.projects;
+	}
+	
+	public boolean removeProject(String projectName) {
+		for(Project currentProject : this.getProjects()) {
+			String currentProjectName = currentProject.getProjectName();
+			if(currentProjectName.equals(projectName)) {
+				this.projects.remove(currentProject);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseProjects() {
+		this.projects = new ArrayList<Project>();
 	}
 	
 	public void addSoftwareSkill(String softwareSkill){
-		softwareSkills.add(softwareSkill);
+		this.softwareSkills.add(softwareSkill);
 	}
 	
 	public List<String> getSoftwareSkills(){
-		return softwareSkills;
+		return this.softwareSkills;
+	}
+	
+	public boolean removeSoftwareSkill(String skill) {
+		return this.softwareSkills.remove(skill);
+	}
+	
+	public void eraseSoftwareSkills() {
+		this.softwareSkills = new ArrayList<String>();
 	}
 	
 	public void addProgrammingLanguageSkill(String programmingLanguageSkill){
-		programmingLanguageSkills.add(programmingLanguageSkill);
+		this.programmingLanguageSkills.add(programmingLanguageSkill);
 	}
 	
 	public List<String> getProgrammingLanguageSkills(){
-		return programmingLanguageSkills;
+		return this.programmingLanguageSkills;
+	}
+	
+	public boolean removeProgrammingLanguageSkill(String skill) {
+		return this.programmingLanguageSkills.remove(skill);
+	}
+	
+	public void eraseProgrammingLanguageSkills() {
+		this.programmingLanguageSkills = new ArrayList<String>();
 	}
 	
 	public void addCertification(Certification certification) {
-		certifications.add(certification);
+		this.certifications.add(certification);
 	}
 	
 	public List<Certification> getCertifications(){
-		return certifications;
+		return this.certifications;
+	}
+	
+	public boolean removeCertification(String certificationTitle) {
+		for(Certification currentCertification : this.getCertifications()) {
+			String currentCertTitle = currentCertification.getCertificationTitle();
+			if(currentCertTitle.equals(certificationTitle)) {
+				this.certifications.remove(currentCertification);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseCertifications() {
+		this.certifications = new ArrayList<Certification>();
 	}
 	
 	public void printContactInfo() {

--- a/src/resumeBuilder/TechnicalResume.java
+++ b/src/resumeBuilder/TechnicalResume.java
@@ -82,7 +82,7 @@ public class TechnicalResume implements Resume {
 		System.out.println("Contact Information");
 		System.out.println("-------------");
 		
-		this.contactInfo.toString();
+		System.out.println(this.contactInfo.toString());
 	}
 	
 	public void printSchools() {

--- a/src/resumeBuilder/TechnicalResumeMenu.java
+++ b/src/resumeBuilder/TechnicalResumeMenu.java
@@ -24,8 +24,9 @@ public class TechnicalResumeMenu implements Menu {
 		System.out.println("5. Software Skills");
 		System.out.println("6. Programming Language Skills");
 		System.out.println("7. Certifications");
-		System.out.println("8. Save as word document");
-		System.out.println("9. Exit");
+		System.out.println("8. View current content");
+		System.out.println("9. Save as word document");
+		System.out.println("10. Exit");
 	}
 
 	@Override
@@ -62,7 +63,10 @@ public class TechnicalResumeMenu implements Menu {
 		} else if (technicalResumeOption==7) {				
 			currentTechnicalResume=processCertifications((TechnicalResume) currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
-		} else if (technicalResumeOption==8) {				
+		} else if(technicalResumeOption==8) {
+			((TechnicalResume) currentTechnicalResume).printTechnicalResume();
+			resetMenu(currentTechnicalResume);
+		} else if (technicalResumeOption==9) {				
 			System.out.println("Word Doc creation currently unsupported for our technical resume template.");
 			resetMenu(currentTechnicalResume);
 //			String filePath = promptForDestination();

--- a/src/resumeBuilder/TechnicalResumeMenu.java
+++ b/src/resumeBuilder/TechnicalResumeMenu.java
@@ -16,7 +16,7 @@ public class TechnicalResumeMenu implements Menu {
 
 	@Override
 	public void displayMenu() {
-		System.out.println("Please select the information you would like to add next.");
+		System.out.println("Please select the information you would like to add/edit next.");
 		System.out.println("1. Contact Information");
 		System.out.println("2. Academic History");
 		System.out.println("3. Work Experience");
@@ -80,6 +80,9 @@ public class TechnicalResumeMenu implements Menu {
 
 	@Override
 	public Resume processContactInformation(Resume currentTechnicalResume) {
+		System.out.println("If you have already entered contact information, what you are entering now will replace that.");
+		System.out.println();
+		
 		System.out.println("Please enter your full name.");
 		String firstName = keyboardIn.nextLine(); 
 		

--- a/src/resumeBuilder/TechnicalResumeMenu.java
+++ b/src/resumeBuilder/TechnicalResumeMenu.java
@@ -46,22 +46,22 @@ public class TechnicalResumeMenu implements Menu {
 			currentTechnicalResume=processContactInformation(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if (technicalResumeOption==2) {
-			currentTechnicalResume=processAcademicInformation(currentTechnicalResume);
+			currentTechnicalResume=addOrRemoveSchool(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if (technicalResumeOption==3) {
-			currentTechnicalResume=processWorkExperience(currentTechnicalResume);
+			currentTechnicalResume=addOrRemoveJob(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if (technicalResumeOption==4) {				
-			currentTechnicalResume=processProjectHistory((TechnicalResume) currentTechnicalResume);
+			currentTechnicalResume=addOrRemoveProject(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if (technicalResumeOption==5) {				
-			currentTechnicalResume=processSkills((TechnicalResume) currentTechnicalResume, "software");
+			currentTechnicalResume=addOrRemoveSoftwareSkill(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if (technicalResumeOption==6) {				
-			currentTechnicalResume=processSkills((TechnicalResume) currentTechnicalResume, "programming language");
+			currentTechnicalResume=addOrRemoveProgrammingLanguageSkill(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if (technicalResumeOption==7) {				
-			currentTechnicalResume=processCertifications((TechnicalResume) currentTechnicalResume);
+			currentTechnicalResume=addOrRemoveCertification(currentTechnicalResume);
 			resetMenu(currentTechnicalResume);
 		} else if(technicalResumeOption==8) {
 			((TechnicalResume) currentTechnicalResume).printTechnicalResume();
@@ -251,6 +251,196 @@ public class TechnicalResumeMenu implements Menu {
 		Certification currentCertification = new Certification(certificationTitle, hostName, dateEarned, details);
 		
 		currentTechnicalResume.addCertification(currentCertification);
+		
+		return currentTechnicalResume;
+	}
+	
+	public void displayAddOrRemove() {
+		System.out.println("Please select what you would like to do.");
+		System.out.println("1. Add an entry.");
+		System.out.println("2. Remove an entry.");
+		System.out.println("3. Erase all entries.");
+		System.out.println("4. Return");
+	}
+	
+	public int promptForAddOrRemove() {
+		displayAddOrRemove();
+		
+		int selection = getMenuSelection();
+		
+		while(selection>4 || selection<1) {
+			System.out.println("That is not a valid selection. Please try again.");
+			displayAddOrRemove();
+			selection = getMenuSelection();
+		}
+		
+		return selection;
+	}
+	
+	public Resume addOrRemoveSchool(Resume currentTechnicalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentTechnicalResume=processAcademicInformation(currentTechnicalResume);	
+		} else if(selection == 2) {
+			currentTechnicalResume=processSchoolRemoval(currentTechnicalResume);
+		} else if(selection == 3) {
+			((TechnicalResume) currentTechnicalResume).eraseSchools();
+			System.out.println("All academic history has been erased.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume processSchoolRemoval(Resume currentTechnicalResume) {
+		System.out.println("Please enter the name of the school you would like to delete (exactly as entered previously.");
+		String schoolName = keyboardIn.nextLine();
+		if(((TechnicalResume) currentTechnicalResume).removeSchool(schoolName)) {
+			System.out.println(schoolName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find school with that name.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume addOrRemoveJob(Resume currentTechnicalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentTechnicalResume=processWorkExperience(currentTechnicalResume);	
+		} else if(selection == 2) {
+			currentTechnicalResume=processJobRemoval(currentTechnicalResume);
+		} else if(selection == 3) {
+			((TechnicalResume) currentTechnicalResume).eraseJobs();
+			System.out.println("All work experience has been erased.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume processJobRemoval(Resume currentTechnicalResume) {
+		System.out.println("Please enter the company name of the job you would like to delete (exactly as entered previously.");
+		String companyName = keyboardIn.nextLine();
+		if(((StandardResume) currentTechnicalResume).removeJob(companyName)) {
+			System.out.println(companyName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find job with that company name.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume addOrRemoveProject(Resume currentTechnicalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentTechnicalResume=processProjectHistory((TechnicalResume) currentTechnicalResume);	
+		} else if(selection == 2) {
+			currentTechnicalResume=processProjectRemoval(currentTechnicalResume);
+		} else if(selection == 3) {
+			((TechnicalResume) currentTechnicalResume).eraseProjects();
+			System.out.println("All projects have been erased.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume processProjectRemoval(Resume currentTechnicalResume) {
+		System.out.println("Please enter the name of the project you would like to delete (exactly as entered previously.");
+		String projectName = keyboardIn.nextLine();
+		if(((TechnicalResume) currentTechnicalResume).removeProject(projectName)) {
+			System.out.println(projectName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find project with that name.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume addOrRemoveSoftwareSkill(Resume currentTechnicalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentTechnicalResume=processSkills((TechnicalResume) currentTechnicalResume, "software");
+		} else if(selection == 2) {
+			currentTechnicalResume=processSoftwareSkillRemoval(currentTechnicalResume);
+		} else if(selection == 3) {
+			((TechnicalResume) currentTechnicalResume).eraseSoftwareSkills();
+			System.out.println("All skills been erased.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume processSoftwareSkillRemoval(Resume currentTechnicalResume) {
+		System.out.println("Please enter the skill you would like to delete (exactly as entered previously.");
+		String skill = keyboardIn.nextLine();
+		if(((TechnicalResume) currentTechnicalResume).removeSoftwareSkill(skill)) {
+			System.out.println(skill+" has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find that skill.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume addOrRemoveProgrammingLanguageSkill(Resume currentTechnicalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentTechnicalResume=processSkills((TechnicalResume) currentTechnicalResume, "programming language");
+		} else if(selection == 2) {
+			currentTechnicalResume=processProgrammingLanguageSkillRemoval(currentTechnicalResume);
+		} else if(selection == 3) {
+			((TechnicalResume) currentTechnicalResume).eraseProgrammingLanguageSkills();
+			System.out.println("All skills been erased.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume processProgrammingLanguageSkillRemoval(Resume currentTechnicalResume) {
+		System.out.println("Please enter the skill you would like to delete (exactly as entered previously.");
+		String skill = keyboardIn.nextLine();
+		if(((TechnicalResume) currentTechnicalResume).removeProgrammingLanguageSkill(skill)) {
+			System.out.println(skill+" has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find that skill.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume addOrRemoveCertification(Resume currentTechnicalResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentTechnicalResume=processCertifications((TechnicalResume) currentTechnicalResume);	
+		} else if(selection == 2) {
+			currentTechnicalResume=processCertificationRemoval(currentTechnicalResume);
+		} else if(selection == 3) {
+			((TechnicalResume) currentTechnicalResume).eraseCertifications();
+			System.out.println("All certifications have been erased.");
+		}
+		
+		return currentTechnicalResume;
+	}
+	
+	public Resume processCertificationRemoval(Resume currentTechnicalResume) {
+		System.out.println("Please enter the title of the certification you would like to delete (exactly as entered previously.");
+		String certificationTitle = keyboardIn.nextLine();
+		if(((TechnicalResume) currentTechnicalResume).removeCertification(certificationTitle)) {
+			System.out.println(certificationTitle+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find certification with that title.");
+		}
 		
 		return currentTechnicalResume;
 	}

--- a/src/resumeBuilder/UndergradResearchResume.java
+++ b/src/resumeBuilder/UndergradResearchResume.java
@@ -34,6 +34,21 @@ public class UndergradResearchResume implements Resume {
 	public List<School> getSchools() {
 		return schools;
 	}
+	
+	public boolean removeSchool(String schoolName) {
+		for(School currentSchool : this.getSchools()) {
+			String currentSchoolName = currentSchool.getSchoolName();
+			if(currentSchoolName.equals(schoolName)) {
+				this.schools.remove(currentSchool);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseSchools() {
+		schools = new ArrayList<School>();
+	}
 
 	@Override
 	public void addJob(Job job) {
@@ -45,12 +60,42 @@ public class UndergradResearchResume implements Resume {
 		return jobs;
 	}
 	
+	public boolean removeJob(String companyName) {
+		for(Job currentJob : this.getJobs()) {
+			String currentCompanyName = currentJob.getCompany();
+			if(currentCompanyName.equals(companyName)) {
+				this.jobs.remove(currentJob);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseJobs() {
+		jobs = new ArrayList<Job>();
+	}
+	
 	public void addActivity(Activity activity) {
 		activities.add(activity);		
 	}
 
 	public List<Activity> getActivities() {
 		return activities;
+	}
+	
+	public boolean removeActivity(String organization) {
+		for(Activity currentActivity : this.getActivities()) {
+			String currentOrganization = currentActivity.getOrganization();
+			if(currentOrganization.equals(organization)) {
+				this.activities.remove(currentActivity);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseActivities() {
+		activities = new ArrayList<Activity>();
 	}
 	
 	public void addSkill(String skill) {
@@ -61,12 +106,35 @@ public class UndergradResearchResume implements Resume {
 		return this.skills;
 	}
 	
+	public boolean removeSkill(String skill) {
+		return this.skills.remove(skill);
+	}
+	
+	public void eraseSkills() {
+		skills = new ArrayList<String>();
+	}
+	
 	public void addCertification(Certification certification) {
 		this.certifications.add(certification);
 	}
 	
 	public List<Certification> getCertifications(){
 		return this.certifications;
+	}
+	
+	public boolean removeCertification(String certificationTitle) {
+		for(Certification currentCertification : this.getCertifications()) {
+			String currentCertTitle = currentCertification.getCertificationTitle();
+			if(currentCertTitle.equals(certificationTitle)) {
+				this.certifications.remove(currentCertification);
+				return true;
+			}
+		}
+		return false;
+	}
+	
+	public void eraseCertifications() {
+		this.certifications = new ArrayList<Certification>();
 	}
 	
 	public void addMemberships(String membership) {
@@ -77,12 +145,28 @@ public class UndergradResearchResume implements Resume {
 		return this.memberships;
 	}
 	
+	public boolean removeMembership(String membership) {
+		return this.memberships.remove(membership);
+	}
+	
+	public void eraseMemberships() {
+		this.memberships = new ArrayList<String>();
+	}
+	
 	public void addConferences(String conference) {
 		this.conferences.add(conference);
 	}
 	
 	public List<String> getConferences() {
 		return this.conferences;
+	}
+	
+	public boolean removeConference(String conference) {
+		return this.conferences.remove(conference);
+	}
+	
+	public void eraseConferences() {
+		this.conferences = new ArrayList<String>();
 	}
 	
 	public void printContactInfo() {

--- a/src/resumeBuilder/UndergradResearchResume.java
+++ b/src/resumeBuilder/UndergradResearchResume.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class UndergradResearchResume implements Resume {
-	ContactInformation contactInfo;
+	ContactInformation contactInfo = new ContactInformation();
 	private List<School> schools = new ArrayList<School>();
 	private List<Job> jobs = new ArrayList<Job>();
 	private List<Activity> activities = new ArrayList<Activity>();
@@ -49,7 +49,7 @@ public class UndergradResearchResume implements Resume {
 		activities.add(activity);		
 	}
 
-	public List<Activity> getActivity() {
+	public List<Activity> getActivities() {
 		return activities;
 	}
 	
@@ -85,5 +85,106 @@ public class UndergradResearchResume implements Resume {
 		return this.conferences;
 	}
 	
-
+	public void printContactInfo() {
+		System.out.println("Contact Information");
+		System.out.println("-------------");
+		
+		this.contactInfo.toString();
+	}
+	
+	public void printSchools() {
+		System.out.println("Academic History");
+		System.out.println("-------------");
+		
+		for(School currentSchool : this.getSchools()) {
+			System.out.println("* "+currentSchool.toString());
+		}
+	}
+	
+	public void printJobs() {
+		System.out.println("Work Experience");
+		System.out.println("-------------");
+		
+		for(Job currentJob : this.getJobs()) {
+			System.out.println("* "+currentJob.toString());
+		}
+	}
+	
+	public void printActivities() {
+		System.out.println("Activities");
+		System.out.println("-------------");
+		
+		for(Activity currentActivity : this.getActivities()) {
+			System.out.println("* "+currentActivity.toString());
+		}
+	}
+	
+	public void printSkills() {
+		System.out.println("Skills");
+		System.out.println("-------------");
+		
+		for(String currentSkill : this.getSkills()) {
+			System.out.println("* "+currentSkill);
+		}
+	}
+	
+	public void printCertifications() {
+		System.out.println("Certifications");
+		System.out.println("-------------");
+		
+		for(Certification currentCertification : this.getCertifications()) {
+			System.out.println("* "+currentCertification.toString());
+		}
+	}
+	
+	public void printMemberships() {
+		System.out.println("Memberships");
+		System.out.println("-------------");
+		
+		for(String currentMembership : this.getMemberships()) {
+			System.out.println("* "+currentMembership);
+		}
+	}
+	
+	public void printConferences() {
+		System.out.println("Conferences");
+		System.out.println("-------------");
+		
+		for(String currentConference : this.getConferences()) {
+			System.out.println("* "+currentConference);
+		}
+	}
+	
+	public void printUndergradResearchResume() {
+		System.out.println();
+		System.out.println("YOUR CURRENT UNDERGRADUATE RESEARCH RESUME CONTENT: ");
+		
+		System.out.println();
+		this.printContactInfo();
+		
+		System.out.println();
+		this.printSchools();
+		
+		System.out.println();
+		this.printJobs();
+		
+		System.out.println();
+		this.printActivities();
+		
+		System.out.println();
+		this.printSkills();
+		
+		System.out.println();
+		this.printCertifications();
+		
+		System.out.println();
+		this.printMemberships();
+		
+		System.out.println();
+		this.printConferences();
+		
+		System.out.println();
+		System.out.println("END OF CONTENT");
+		System.out.println();
+	}
 }

--- a/src/resumeBuilder/UndergradResearchResume.java
+++ b/src/resumeBuilder/UndergradResearchResume.java
@@ -89,7 +89,7 @@ public class UndergradResearchResume implements Resume {
 		System.out.println("Contact Information");
 		System.out.println("-------------");
 		
-		this.contactInfo.toString();
+		System.out.println(this.contactInfo.toString());
 	}
 	
 	public void printSchools() {

--- a/src/resumeBuilder/UndergradResearchResumeMenu.java
+++ b/src/resumeBuilder/UndergradResearchResumeMenu.java
@@ -25,8 +25,9 @@ public class UndergradResearchResumeMenu implements Menu {
 		System.out.println("6. Certifications");
 		System.out.println("7. Organizational Memberships");
 		System.out.println("8. Conferences Attended/Presented");
-		System.out.println("9. Save as word document");
-		System.out.println("10. Exit");
+		System.out.println("9. View current content");
+		System.out.println("10. Save as word document");
+		System.out.println("11. Exit");
 	}
 
 	@Override
@@ -42,7 +43,6 @@ public class UndergradResearchResumeMenu implements Menu {
 
 	@Override
 	public void processMenu(int undergradResearchResumeOption, Resume currentUndergradResearchResume) {
-		// TODO Auto-generated method stub
 		if(undergradResearchResumeOption==1) {
 			currentUndergradResearchResume=processContactInformation(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
@@ -67,7 +67,10 @@ public class UndergradResearchResumeMenu implements Menu {
 		} else if (undergradResearchResumeOption==8) {				
 			currentUndergradResearchResume=processConference((UndergradResearchResume) currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
-		}  else if (undergradResearchResumeOption==9) {
+		}  else if (undergradResearchResumeOption==9) {	
+			((UndergradResearchResume) currentUndergradResearchResume).printUndergradResearchResume();
+			resetMenu(currentUndergradResearchResume);
+		} else if (undergradResearchResumeOption==10) {
 			System.out.println("Cannot create Word document for this resume template yet.");
 //			String filePath = promptForDestination();
 //			WordCreator wordCreator = new WordCreator((StandardResume) currentStandardResume, filePath);

--- a/src/resumeBuilder/UndergradResearchResumeMenu.java
+++ b/src/resumeBuilder/UndergradResearchResumeMenu.java
@@ -47,19 +47,19 @@ public class UndergradResearchResumeMenu implements Menu {
 			currentUndergradResearchResume=processContactInformation(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
 		} else if (undergradResearchResumeOption==2) {
-			currentUndergradResearchResume=processAcademicInformation(currentUndergradResearchResume);
+			currentUndergradResearchResume=addOrRemoveSchool(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
 		} else if (undergradResearchResumeOption==3) {
-			currentUndergradResearchResume=processWorkExperience(currentUndergradResearchResume);
+			currentUndergradResearchResume=addOrRemoveJob(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
 		} else if (undergradResearchResumeOption==4) {				
-			currentUndergradResearchResume=processActivity((UndergradResearchResume) currentUndergradResearchResume);
+			currentUndergradResearchResume=addOrRemoveActivity(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
 		} else if (undergradResearchResumeOption==5) {				
-			currentUndergradResearchResume=processSkill((UndergradResearchResume) currentUndergradResearchResume);
+			currentUndergradResearchResume=addOrRemoveSkill(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
 		} else if (undergradResearchResumeOption==6) {				
-			currentUndergradResearchResume=processCertification((UndergradResearchResume) currentUndergradResearchResume);
+			currentUndergradResearchResume=addOrRemoveCertification(currentUndergradResearchResume);
 			resetMenu(currentUndergradResearchResume);
 		} else if (undergradResearchResumeOption==7) {				
 			currentUndergradResearchResume=processMembership((UndergradResearchResume) currentUndergradResearchResume);
@@ -309,6 +309,168 @@ public class UndergradResearchResumeMenu implements Menu {
 		System.out.println("Exiting academic honors/awards section...");
 		
 		return currentSchool;
+	}
+	
+	public void displayAddOrRemove() {
+		System.out.println("Please select what you would like to do.");
+		System.out.println("1. Add an entry.");
+		System.out.println("2. Remove an entry.");
+		System.out.println("3. Erase all entries.");
+		System.out.println("4. Return");
+	}
+	
+	public int promptForAddOrRemove() {
+		displayAddOrRemove();
+		
+		int selection = getMenuSelection();
+		
+		while(selection>4 || selection<1) {
+			System.out.println("That is not a valid selection. Please try again.");
+			displayAddOrRemove();
+			selection = getMenuSelection();
+		}
+		
+		return selection;
+	}
+	
+	public Resume addOrRemoveSchool(Resume currentUndergradResearchResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentUndergradResearchResume=processAcademicInformation(currentUndergradResearchResume);	
+		} else if(selection == 2) {
+			currentUndergradResearchResume=processSchoolRemoval(currentUndergradResearchResume);
+		} else if(selection == 3) {
+			((UndergradResearchResume) currentUndergradResearchResume).eraseSchools();
+			System.out.println("All academic history has been erased.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume processSchoolRemoval(Resume currentUndergradResearchResume) {
+		System.out.println("Please enter the name of the school you would like to delete (exactly as entered previously.");
+		String schoolName = keyboardIn.nextLine();
+		if(((UndergradResearchResume) currentUndergradResearchResume).removeSchool(schoolName)) {
+			System.out.println(schoolName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find school with that name.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume addOrRemoveJob(Resume currentUndergradResearchResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentUndergradResearchResume=processWorkExperience(currentUndergradResearchResume);
+		} else if(selection == 2) {
+			currentUndergradResearchResume=processJobRemoval(currentUndergradResearchResume);
+		} else if(selection == 3) {
+			((UndergradResearchResume) currentUndergradResearchResume).eraseJobs();
+			System.out.println("All work experience has been erased.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume processJobRemoval(Resume currentUndergradResearchResume) {
+		System.out.println("Please enter the company name of the job or research experience you would like to delete (exactly as entered previously.");
+		String companyName = keyboardIn.nextLine();
+		if(((UndergradResearchResume) currentUndergradResearchResume).removeJob(companyName)) {
+			System.out.println(companyName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find job or research experience with that company name.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume addOrRemoveActivity(Resume currentUndergradResearchResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentUndergradResearchResume=processActivity((UndergradResearchResume) currentUndergradResearchResume);
+		} else if(selection == 2) {
+			currentUndergradResearchResume=processActivityRemoval(currentUndergradResearchResume);
+		} else if(selection == 3) {
+			((UndergradResearchResume) currentUndergradResearchResume).eraseActivities();
+			System.out.println("All activities have been erased.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume processActivityRemoval(Resume currentUndergradResearchResume) {
+		System.out.println("Please enter the organization name of the activity you would like to delete (exactly as entered previously.");
+		String organizationName = keyboardIn.nextLine();
+		if(((UndergradResearchResume) currentUndergradResearchResume).removeActivity(organizationName)) {
+			System.out.println(organizationName+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find activity with that organization name.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume addOrRemoveSkill(Resume currentUndergradResearchResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentUndergradResearchResume=processSkill((UndergradResearchResume) currentUndergradResearchResume);
+		} else if(selection == 2) {
+			currentUndergradResearchResume=processSkillRemoval(currentUndergradResearchResume);
+		} else if(selection == 3) {
+			((UndergradResearchResume) currentUndergradResearchResume).eraseSkills();
+			System.out.println("All skills been erased.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume processSkillRemoval(Resume currentUndergradResearchResume) {
+		System.out.println("Please enter the skill you would like to delete (exactly as entered previously.");
+		String skill = keyboardIn.nextLine();
+		if(((UndergradResearchResume) currentUndergradResearchResume).removeSkill(skill)) {
+			System.out.println(skill+" has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find that skill.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume addOrRemoveCertification(Resume currentUndergradResearchResume) {
+		int selection = promptForAddOrRemove();
+		
+		if(selection == 1) {
+			currentUndergradResearchResume=processCertification((UndergradResearchResume) currentUndergradResearchResume);	
+		} else if(selection == 2) {
+			currentUndergradResearchResume=processCertificationRemoval(currentUndergradResearchResume);
+		} else if(selection == 3) {
+			((UndergradResearchResume) currentUndergradResearchResume).eraseCertifications();
+			System.out.println("All certifications have been erased.");
+		}
+		
+		return currentUndergradResearchResume;
+	}
+	
+	public Resume processCertificationRemoval(Resume currentUndergradResearchResume) {
+		System.out.println("Please enter the title of the certification you would like to delete (exactly as entered previously.");
+		String certificationTitle = keyboardIn.nextLine();
+		if(((UndergradResearchResume) currentUndergradResearchResume).removeCertification(certificationTitle)) {
+			System.out.println(certificationTitle+" and all associated data has been deleted.");
+		}
+		else {
+			System.out.println("Deletion unsuccessful. Couldn't find certification with that title.");
+		}
+		
+		return currentUndergradResearchResume;
 	}
 
 	@Override

--- a/src/resumeBuilder/UndergradResearchResumeMenu.java
+++ b/src/resumeBuilder/UndergradResearchResumeMenu.java
@@ -16,7 +16,7 @@ public class UndergradResearchResumeMenu implements Menu {
 
 	@Override
 	public void displayMenu() {
-		System.out.println("Please select the information you would like to add next.");
+		System.out.println("Please select the information you would like to add/edit next.");
 		System.out.println("1. Contact Information");
 		System.out.println("2. Academic History");
 		System.out.println("3. Research and/or Work Experience");
@@ -83,6 +83,9 @@ public class UndergradResearchResumeMenu implements Menu {
 
 	@Override
 	public Resume processContactInformation(Resume currentUndergradResearchResume) {
+		System.out.println("If you have already entered contact information, what you are entering now will replace that.");
+		System.out.println();
+		
 		System.out.println("Please enter your full name.");
 		String firstName = keyboardIn.nextLine(); 
 		


### PR DESCRIPTION
This is a big one! 

Basically the structure I implemented is this:
User chooses template --> User chooses area of resume to focus on --> User given option to add or remove an entry or remove all entries for that section --> (What happens next is up to the user. If they choose to add, things proceed just as normal. If they choose to remove, the program will prompt for some kind of information about the entry they want to remove.)

I only implemented this structure for objects stored in lists (Jobs, Schools, References, etc.). Basic strings (clearance, citizenship status, etc) and contact info are simply overwritten if someone goes to reenter them (and I added lines to those prompts to clarify that).

The idea is that users can view the content they've entered so far (I implemented this for every resume as a menu option), and then go back to remove content they don't want.

I know one conflict is because I worked on this before Owen's Word creation merge, but the rest is from restructuring. (e.g. I had to manipulate some instance variables of resumes to make toStrings and printing function properly.)